### PR TITLE
fixing workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -9,6 +9,8 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
+    with:
+      inject_mupdate: true
     secrets: inherit
     permissions:
       contents: write

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "ThreshColorPercent",
   "title": "Add colors to percents in Health bars",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "gesslar",
   "icon": "percent.png",
   "dependencies": "",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two minor fixes: it adds the `inject_mupdate: true` parameter to the reusable `ReleaseMudlet.yaml` workflow call, and bumps the package version from `2.0.0` to `2.0.1` in `mfile`.

- Added `with: inject_mupdate: true` to the `Release.yaml` workflow job, enabling Mudlet update injection during release
- Patched version from `2.0.0` → `2.0.1` in `mfile`
- The workflow correctly targets `@main` on the reusable workflow reference, satisfying the Gesslar Extended Universe policy

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the changes are minimal, intentional, and correct.

Two focused changes: adding a well-formed workflow input parameter and a patch version bump. The workflow reference already targets @main per policy. No logic errors or security concerns.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fixing workflow"](https://github.com/gesslar/threshcolorpercent/commit/f98c1cd9f9051ba464e68a74d9a8465606d7dbbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28253833)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->